### PR TITLE
Support asttokens v3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     ],
 
     install_requires=(
-        'asttokens >=2, <3',
+        'asttokens >=2, <4',
     ),
     python_requires='>=3.7',
 )


### PR DESCRIPTION
From what I recall v3 doesn't change any APIs, just drops Python 2 support.